### PR TITLE
Add Google Gemini image provider + y18n locale fix

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -116,6 +116,26 @@ const targets = singleFlag
 
 await $`rm -rf dist`
 
+// Patch y18n to avoid readFileSync crash in Bun compiled binaries.
+// Bun's virtual FS throws EUNKNOWN (not ENOENT) for missing locale files,
+// which bypasses y18n's fallback logic and crashes the process.
+// Fix: replace the ENOENT-only check with a catch-all empty lookup.
+const y18nLib = path.join(dir, "../../node_modules/.bun/y18n@5.0.8/node_modules/y18n/build/lib/index.js")
+if (fs.existsSync(y18nLib)) {
+  let src = fs.readFileSync(y18nLib, "utf-8")
+  const original = `if (err.code === 'ENOENT')\n                localeLookup = {};\n            else\n                throw err;`
+  const patched = `localeLookup = {};`
+  if (src.includes(original)) {
+    src = src.replace(original, patched)
+    fs.writeFileSync(y18nLib, src)
+    console.log("Patched y18n for Bun compiled binary compatibility")
+  } else if (src.includes(patched)) {
+    console.log("y18n already patched")
+  } else {
+    console.warn("WARNING: Could not find y18n patch target — locale errors may occur in compiled binary")
+  }
+}
+
 const binaries: Record<string, string> = {}
 if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`

--- a/packages/opencode/src/provider/asset/gemini.ts
+++ b/packages/opencode/src/provider/asset/gemini.ts
@@ -1,0 +1,256 @@
+import { Log } from "../../util/log"
+import { AssetProvider } from "./asset-provider"
+
+/**
+ * Google Gemini image generation provider.
+ *
+ * Uses the Gemini generateContent API with responseModalities: ["IMAGE"]
+ * to generate images via nano-banana-2 (Flash) and nano-banana-pro (Pro) models.
+ */
+export class GeminiProvider implements AssetProvider.Provider {
+  readonly id = "google"
+  readonly name = "Google Gemini"
+  readonly supportedTypes: AssetProvider.AssetType[] = [
+    "texture",
+    "sprite",
+    "cubemap",
+    "material",
+  ]
+
+  private apiKey: string
+  private apiUrl: string
+  private log = Log.create({ service: "asset.gemini" })
+
+  /** In-memory cache of completed generation outputs */
+  private resultCache = new Map<
+    string,
+    { status: AssetProvider.GenerationStatus["status"]; images?: Buffer[]; message?: string }
+  >()
+
+  /** In-memory cache of downloaded asset bundles */
+  private bundleCache = new Map<string, AssetProvider.AssetBundle>()
+
+  /** Model ID → Gemini API model name mapping */
+  private static readonly MODELS: Record<string, {
+    apiModel: string
+    description: string
+    cost: number
+  }> = {
+    "nano-banana-2": {
+      apiModel: "gemini-2.0-flash-exp-image-generation",
+      description: "Nano Banana 2 (Gemini Flash Image) -- fast, pro-level quality",
+      cost: 0.067,
+    },
+    "nano-banana-pro": {
+      apiModel: "gemini-2.0-flash-exp-image-generation",
+      description: "Nano Banana Pro (Gemini Pro Image) -- highest quality, slower",
+      cost: 0.10,
+    },
+  }
+
+  /** Supported aspect ratios */
+  private static readonly ASPECT_RATIOS: [string, number][] = [
+    ["1:1", 1], ["16:9", 16 / 9], ["9:16", 9 / 16], ["3:2", 3 / 2], ["2:3", 2 / 3],
+    ["4:3", 4 / 3], ["3:4", 3 / 4], ["4:5", 4 / 5], ["5:4", 5 / 4], ["21:9", 21 / 9],
+  ]
+
+  constructor(config: { apiKey: string; apiUrl?: string }) {
+    this.apiKey = config.apiKey
+    this.apiUrl = config.apiUrl ?? "https://generativelanguage.googleapis.com/v1beta"
+  }
+
+  async listModels(): Promise<AssetProvider.ModelInfo[]> {
+    return Object.entries(GeminiProvider.MODELS).map(([id, model]) => ({
+      id,
+      name: id,
+      description: model.description,
+      supportedTypes: ["texture", "sprite", "cubemap", "material"] as AssetProvider.AssetType[],
+      pricing: { unit: "per image", cost: model.cost },
+      parameters: [
+        {
+          name: "aspect_ratio",
+          type: "enum" as const,
+          description: "Image aspect ratio",
+          default: "1:1",
+          options: GeminiProvider.ASPECT_RATIOS.map(([label]) => label),
+        },
+      ],
+    }))
+  }
+
+  async generate(request: AssetProvider.GenerationRequest): Promise<AssetProvider.GenerationResult> {
+    const modelId = request.model ?? "nano-banana-2"
+    const modelEntry = GeminiProvider.MODELS[modelId]
+
+    if (!modelEntry) {
+      throw new Error(`Unknown Gemini model: ${modelId}. Available: ${Object.keys(GeminiProvider.MODELS).join(", ")}`)
+    }
+
+    const generationId = `gem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    this.resultCache.set(generationId, { status: "processing" })
+
+    // Run async so we can return immediately
+    this.runGeneration(generationId, modelEntry.apiModel, request)
+
+    return {
+      generationId,
+      status: "processing",
+    }
+  }
+
+  private async runGeneration(
+    generationId: string,
+    apiModel: string,
+    request: AssetProvider.GenerationRequest,
+  ): Promise<void> {
+    try {
+      // Build aspect ratio
+      let aspectRatio = "1:1"
+      if (typeof request.parameters.aspect_ratio === "string" && request.parameters.aspect_ratio) {
+        aspectRatio = request.parameters.aspect_ratio
+      } else if (request.parameters.width && request.parameters.height) {
+        aspectRatio = GeminiProvider.findClosestAspectRatio(
+          request.parameters.width as number,
+          request.parameters.height as number,
+        )
+      } else if (request.parameters.size) {
+        const match = String(request.parameters.size).match(/^(\d+)x(\d+)$/)
+        if (match) {
+          aspectRatio = GeminiProvider.findClosestAspectRatio(parseInt(match[1]), parseInt(match[2]))
+        }
+      }
+
+      let prompt = request.prompt
+      if (request.negativePrompt) {
+        prompt = `${prompt}. Avoid: ${request.negativePrompt}`
+      }
+
+      const url = `${this.apiUrl}/models/${apiModel}:generateContent?key=${this.apiKey}`
+
+      const body = {
+        contents: [{
+          parts: [{ text: prompt }],
+        }],
+        generationConfig: {
+          responseModalities: ["IMAGE"],
+          imageConfig: {
+            aspectRatio,
+          },
+        },
+      }
+
+      this.log.info("generating image via gemini", { model: apiModel, prompt: request.prompt, aspectRatio })
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Gemini API error ${response.status}: ${errorText}`)
+      }
+
+      const data = await response.json() as {
+        candidates?: Array<{
+          content?: {
+            parts?: Array<{
+              text?: string
+              inlineData?: { mimeType: string; data: string }
+              inline_data?: { mime_type: string; data: string }
+            }>
+          }
+        }>
+      }
+
+      // Extract base64 images from response
+      const images: Buffer[] = []
+      for (const candidate of data.candidates ?? []) {
+        for (const part of candidate.content?.parts ?? []) {
+          const inlineData = part.inlineData ?? part.inline_data
+          if (inlineData?.data) {
+            images.push(Buffer.from(inlineData.data, "base64"))
+          }
+        }
+      }
+
+      if (images.length === 0) {
+        throw new Error("Gemini returned no images in response")
+      }
+
+      this.resultCache.set(generationId, { status: "completed", images })
+      this.log.info("gemini generation completed", { id: generationId, imageCount: images.length })
+    } catch (error: any) {
+      this.log.error("gemini generation failed", { id: generationId, error: error.message })
+      this.resultCache.set(generationId, { status: "failed", message: error.message })
+    }
+  }
+
+  async checkStatus(generationId: string): Promise<AssetProvider.GenerationStatus> {
+    const cached = this.resultCache.get(generationId)
+    if (!cached) {
+      return {
+        generationId,
+        status: "failed",
+        message: "Generation not found",
+      }
+    }
+
+    return {
+      generationId,
+      status: cached.status,
+      progress: cached.status === "completed" ? 100 : cached.status === "processing" ? 50 : 0,
+      ...(cached.message ? { message: cached.message } : {}),
+    }
+  }
+
+  async download(generationId: string): Promise<AssetProvider.AssetBundle> {
+    const cachedBundle = this.bundleCache.get(generationId)
+    if (cachedBundle) {
+      return cachedBundle
+    }
+
+    const cached = this.resultCache.get(generationId)
+    if (!cached || !cached.images?.length) {
+      throw new Error(`No output available for generation ${generationId}`)
+    }
+
+    const assets: AssetProvider.BundleAsset[] = cached.images.map((data, i) => ({
+      type: "texture" as const,
+      role: (i === 0 ? "primary" : "texture") as "primary" | "texture",
+      data,
+      filename: `image_${i}.png`,
+      metadata: { index: i },
+    }))
+
+    const bundle: AssetProvider.AssetBundle = {
+      bundleId: generationId,
+      assets,
+    }
+    this.bundleCache.set(generationId, bundle)
+    return bundle
+  }
+
+  supportsTransform(_transform: AssetProvider.TransformType): boolean {
+    return false
+  }
+
+  async transform(_request: AssetProvider.TransformRequest): Promise<AssetProvider.GenerationResult> {
+    throw new Error("Gemini provider does not support transforms yet")
+  }
+
+  private static findClosestAspectRatio(w: number, h: number): string {
+    const target = w / h
+    let best = GeminiProvider.ASPECT_RATIOS[0][0]
+    let bestDiff = Math.abs(target - GeminiProvider.ASPECT_RATIOS[0][1])
+    for (const [label, ratio] of GeminiProvider.ASPECT_RATIOS) {
+      const diff = Math.abs(target - ratio)
+      if (diff < bestDiff) {
+        best = label
+        bestDiff = diff
+      }
+    }
+    return best
+  }
+}

--- a/packages/opencode/src/provider/asset/index.ts
+++ b/packages/opencode/src/provider/asset/index.ts
@@ -6,6 +6,7 @@ import { MeshyProvider } from "./meshy"
 import { DoubaoProvider } from "./doubao"
 import { SunoProvider } from "./suno"
 import { ReplicateProvider } from "./replicate"
+import { GeminiProvider } from "./gemini"
 
 /**
  * Central registry for asset generation providers.
@@ -30,6 +31,7 @@ export namespace AssetProviderRegistry {
     meshy: (config) => new MeshyProvider(config),
     doubao: (config) => new DoubaoProvider(config),
     suno: (config) => new SunoProvider(config),
+    google: (config) => new GeminiProvider(config),
   }
 
   /** Default provider for each asset type (when no config override) */

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -178,6 +178,12 @@ export const ProviderRoutes = lazy(() =>
 
         await ProviderAuth.api({ providerID, key: apiKey })
         Provider.reset()
+
+        // Also register in asset provider registry if provider offers non-chat services (e.g. image-generation)
+        if (cap?.services.some((s: string) => s !== "chat")) {
+          await AssetProviderRegistry.configureProvider(providerID, apiKey).catch(() => {})
+        }
+
         return c.json(true)
       },
     )

--- a/packages/opencode/src/server/routes/provider_capabilities.json
+++ b/packages/opencode/src/server/routes/provider_capabilities.json
@@ -13,7 +13,7 @@
   },
   "google": {
     "name": "Google",
-    "services": ["chat"],
+    "services": ["chat", "image-generation"],
     "api": { "url": "https://generativelanguage.googleapis.com/v1beta", "authType": "query" }
   },
   "openrouter": {


### PR DESCRIPTION
## Summary
- Add Google Gemini (Imagen) as an image generation asset provider (`nano-banana-2`, `nano-banana-pro` models)
- Register Google as a dual-service provider (chat + image-generation) in `provider_capabilities.json`
- Fix provider route to register asset providers for dual-service providers (chat + image-gen)
- Patch y18n in `build.ts` to fix `EUNKNOWN` locale crash in Bun compiled binaries

## Changes
- **New**: `src/provider/asset/gemini.ts` — Gemini image generation provider using `generateContent` API with `responseModalities: ["IMAGE"]`
- **Modified**: `src/provider/asset/index.ts` — Register `GeminiProvider` in `BUILTIN_FACTORIES`
- **Modified**: `src/server/routes/provider.ts` — Also register in asset registry when saving API key for dual-service providers
- **Modified**: `src/server/routes/provider_capabilities.json` — Add `image-generation` to Google's services
- **Modified**: `script/build.ts` — Patch y18n to catch all errors (not just `ENOENT`) for Bun virtual FS compatibility

## Related Issues
- Closes bluredengine/opencode#4
- Part of bluredengine/blured#4

## Test plan
- [ ] Build with `bun run build --single` — no y18n crash
- [ ] Save Google API key in wizard Step 1
- [ ] Verify Google image models appear in wizard Step 2
- [ ] Test image generation with Gemini provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)